### PR TITLE
Add collection group query support to Firestore

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,3 +58,5 @@ For testing, the following environment variables need to be set so the tests can
 - `FIREBASE_PRIVATE_KEY_ID`
 
 They should correspond to their values from the service account JSON file.
+
+Additionally, some of the Firestore tests may need indices to be created. See the error messages for which.

--- a/src/firestore/client/mod.rs
+++ b/src/firestore/client/mod.rs
@@ -684,11 +684,11 @@ impl FirestoreClient {
             // ignore those items.
             .filter(|res| match res {
                 Ok(inner) => future::ready(inner.document.is_some()),
-                Err(_) => future::ready(false),
+                Err(_) => future::ready(true),
             })
             .map(|res| {
                 let doc = res
-                    .context("Error response in query")?
+                    .map_err(|e| anyhow::anyhow!(e))?
                     .document
                     .context("No document in response - illegal state")?;
 

--- a/src/firestore/client/mod.rs
+++ b/src/firestore/client/mod.rs
@@ -700,6 +700,97 @@ impl FirestoreClient {
         Ok(doc_stream.boxed())
     }
 
+    /// Fetch all documents from any collection with the given name.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # #[tokio::main]
+    /// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// # let mut client = fireplace::firestore::test_helpers::initialise().await?;
+    /// use fireplace::firestore::collection;
+    /// use futures::TryStreamExt;
+    /// use serde::Deserialize;
+    ///
+    /// // Populate the database with some documents across different collections which
+    /// // we can fetch
+    /// client
+    ///     .set_document(
+    ///         &collection("cities")
+    ///             .doc("SF")
+    ///             .collection("landmarks")
+    ///             .doc("golden-gate"),
+    ///         &serde_json::json!({ "name": "Golden Gate Bridge", "type": "bridge" }),
+    ///     )
+    ///     .await?;
+    /// client
+    ///     .set_document(
+    ///         &collection("cities")
+    ///             .doc("SF")
+    ///             .collection("landmarks")
+    ///             .doc("legion-honor"),
+    ///         &serde_json::json!({ "name": "Legion of Honor", "type": "museum" }),
+    ///     )
+    ///     .await?;
+    /// client
+    ///     .set_document(
+    ///         &collection("cities")
+    ///             .doc("TOK")
+    ///             .collection("landmarks")
+    ///             .doc("national-science-museum"),
+    ///         &serde_json::json!({ "name": "National Museum of Nature and Science", "type": "museum" }),
+    ///     )
+    ///     .await?;
+    ///
+    /// #[derive(Deserialize, Debug, PartialEq)]
+    /// struct Landmark {
+    ///     pub name: String,
+    ///     pub r#type: String,
+    /// }
+    ///
+    /// let mut landmarks: Vec<Landmark> = client
+    ///     .collection_group("landmarks")
+    ///     .await?
+    ///     .try_collect()
+    ///     .await?;
+    ///
+    /// // We don't know which order the documents will be returned in, so we sort them
+    /// landmarks.sort_by(|a, b| a.name.cmp(&b.name));
+    ///
+    /// assert_eq!(
+    ///     landmarks,
+    ///     vec![
+    ///         Landmark {
+    ///             name: "Golden Gate Bridge".to_string(),
+    ///             r#type: "bridge".to_string()
+    ///         },
+    ///         Landmark {
+    ///             name: "Legion of Honor".to_string(),
+    ///             r#type: "museum".to_string()
+    ///         },
+    ///         Landmark {
+    ///             name: "National Museum of Nature and Science".to_string(),
+    ///             r#type: "museum".to_string()
+    ///         },
+    ///     ]
+    /// );
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub async fn collection_group<'de, T: Deserialize<'de>>(
+        &mut self,
+        collection_name: impl Into<String>,
+    ) -> Result<FirebaseStream<T, FirebaseError>, FirebaseError> {
+        self.query_internal(ApiQueryOptions {
+            parent: self.root_resource_path.clone(),
+            collection_name: collection_name.into(),
+            filter: None,
+            limit: None,
+            should_search_descendants: true,
+        })
+        .await
+    }
+
     fn get_name_with(&self, item: impl Display) -> String {
         format!("{}/{}", self.root_resource_path, item)
     }

--- a/src/firestore/client/mod.rs
+++ b/src/firestore/client/mod.rs
@@ -274,14 +274,10 @@ impl FirestoreClient {
         // according to Google's Firestore API reference.
         let doc = serialize_to_document(document, None, None, None)?;
 
-        let parent = collection_ref
-            .parent()
-            .map(|parent_doc| self.get_name_with(&parent_doc))
-            .unwrap_or_else(|| self.root_resource_path.clone());
-
+        let (parent, collection_name) = self.split_collection_parent_and_name(collection_ref);
         let request = CreateDocumentRequest {
             parent,
-            collection_id: collection_ref.name().to_string(),
+            collection_id: collection_name,
             // Passing an empty string means that Firestore will generate a
             // document ID for us.
             document_id: document_id.unwrap_or_default(),

--- a/src/firestore/query.rs
+++ b/src/firestore/query.rs
@@ -187,6 +187,15 @@ impl From<FieldFilter> for GrpcFilter {
     }
 }
 
+pub(crate) struct ApiQueryOptions {
+    pub parent: String,
+    pub collection_name: String,
+    pub filter: Option<Filter>,
+    pub limit: Option<i32>,
+    /// Whether to search descendant collections with the same name
+    pub should_search_descendants: bool,
+}
+
 #[cfg(test)]
 mod tests {
     use firestore_grpc::v1::{structured_query, value::ValueType};


### PR DESCRIPTION
Closes #15

Additionally, it fixes a small bug where all erroneus responses for any query-like method was discarded, making it *very hard* to debug why an empty list was returned.... Didn't at all spend too much time on that... It's been fixed now so errors from the Firestore gRPC API are preserved, such as "missing index".