### PR TITLE
Serialize and deserialize reference types

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ futures = "0.3"
 reqwest = { version = "0.11", features = ["json"] }
 tracing = "0.1"
 openssl = "0.10"
+once_cell = "1.16"
 
 [dev-dependencies]
 ulid = "1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ reqwest = { version = "0.11", features = ["json"] }
 tracing = "0.1"
 openssl = "0.10"
 once_cell = "1.16"
+erased-serde = "0.3"
 
 [dev-dependencies]
 ulid = "1.0"

--- a/src/firestore/client/mod.rs
+++ b/src/firestore/client/mod.rs
@@ -580,7 +580,7 @@ impl FirestoreClient {
     ///
     /// // Query for pizzas whose name field is "Hawaii"
     /// let hawaii_results: Vec<Pizza> = client
-    ///     .query(&collection("pizzas"), filter("name", EqualTo("Hawaii"))?)
+    ///     .query(&collection("pizzas"), filter("name", EqualTo("Hawaii")))
     ///     .await?
     ///     .try_collect()
     ///     .await?;
@@ -592,7 +592,7 @@ impl FirestoreClient {
     /// let mut cheese_results: Vec<Pizza> = client
     ///     .query(
     ///         &collection("pizzas"),
-    ///         filter("toppings", ArrayContains("cheese"))?,
+    ///         filter("toppings", ArrayContains("cheese")),
     ///     )
     ///     .await?
     ///     .try_collect()
@@ -607,7 +607,7 @@ impl FirestoreClient {
     ///
     /// // Query for pizzas with the name "pasta salad".
     /// let mut pasta_salad_results: Vec<Pizza> = client
-    ///     .query(&collection("pizzas"), filter("name", EqualTo("pasta salad"))?)
+    ///     .query(&collection("pizzas"), filter("name", EqualTo("pasta salad")))
     ///     .await?
     ///     .try_collect()
     ///     .await?;
@@ -663,7 +663,7 @@ impl FirestoreClient {
     /// let mut margherita_result: Option<Pizza> = client
     ///     .query_one(
     ///         &collection("pizzas"),
-    ///         filter("name", EqualTo("Margherita"))?,
+    ///         filter("name", EqualTo("Margherita")),
     ///     )
     ///     .await?;
     ///
@@ -672,7 +672,7 @@ impl FirestoreClient {
     ///
     /// // Query for pizzas with the name "pasta salad".
     /// let mut pasta_salad_result: Option<Pizza> = client
-    ///     .query_one(&collection("pizzas"), filter("name", EqualTo("pasta salad"))?)
+    ///     .query_one(&collection("pizzas"), filter("name", EqualTo("pasta salad")))
     ///     .await?;
     ///
     /// // We expect no results
@@ -900,7 +900,7 @@ impl FirestoreClient {
     /// }
     ///
     /// let mut landmarks: Vec<Landmark> = client
-    ///     .collection_group_query("landmarks", filter("type", EqualTo("museum"))?)
+    ///     .collection_group_query("landmarks", filter("type", EqualTo("museum")))
     ///     .await?
     ///     .try_collect()
     ///     .await?;

--- a/src/firestore/client/mod.rs
+++ b/src/firestore/client/mod.rs
@@ -277,7 +277,7 @@ impl FirestoreClient {
     ) -> Result<String, FirebaseError> {
         // We should provide no name or timestamps when creating a document
         // according to Google's Firestore API reference.
-        let doc = DocumentSerializer::new(self.root_resource_path.clone()).serialize(document)?;
+        let doc = self.serializer().serialize(document)?;
 
         let (parent, collection_name) = self.split_collection_parent_and_name(collection_ref);
         let request = CreateDocumentRequest {

--- a/src/firestore/query.rs
+++ b/src/firestore/query.rs
@@ -136,7 +136,8 @@ fn create_field_filter<T: Serialize>(
     query_op: impl QueryOperator<T>,
 ) -> Result<FieldFilter, FirebaseError> {
     let val = query_op.get_value();
-    let value_type = serialize_to_value_type(val)?;
+    // DONT MERGE THIS
+    let value_type = serialize_to_value_type(val, "")?;
     let firestore_value = Value {
         value_type: Some(value_type),
     };

--- a/src/firestore/reference.rs
+++ b/src/firestore/reference.rs
@@ -186,6 +186,18 @@ impl std::fmt::Display for DocumentReference {
     }
 }
 
+impl PartialEq for CollectionReference {
+    fn eq(&self, other: &Self) -> bool {
+        self.to_string() == other.to_string()
+    }
+}
+
+impl PartialEq for DocumentReference {
+    fn eq(&self, other: &Self) -> bool {
+        self.to_string() == other.to_string()
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/firestore/reference.rs
+++ b/src/firestore/reference.rs
@@ -1,9 +1,14 @@
-use std::sync::Arc;
+use std::{any::TypeId, sync::Arc};
+
+use anyhow::Context;
+use once_cell::sync::OnceCell;
+use serde::{ser::SerializeStruct, Deserialize, Deserializer, Serialize, Serializer};
 
 pub fn collection(name: impl Into<String>) -> CollectionReference {
     CollectionReference::new(name)
 }
 
+/// A reference to a Firestore document.
 #[derive(Debug, Clone)]
 pub struct DocumentReference(Arc<DocumentReferenceInner>);
 
@@ -21,6 +26,8 @@ struct DocumentReferenceInner {
     parent: CollectionReference,
     id: String,
 }
+
+static COLLECTION_REF_TYPE_ID: OnceCell<String> = OnceCell::new();
 
 impl CollectionReference {
     pub fn new(collection_name: impl Into<String>) -> Self {
@@ -44,7 +51,58 @@ impl CollectionReference {
     pub fn name(&self) -> &str {
         &self.0.name
     }
+
+    pub(crate) fn type_id() -> &'static str {
+        COLLECTION_REF_TYPE_ID.get_or_init(|| format!("{:?}", TypeId::of::<Self>()))
+    }
 }
+
+impl Serialize for CollectionReference {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let mut s = serializer.serialize_struct(Self::type_id(), 1)?;
+        s.serialize_field("relative_path", &self.to_string())?;
+        s.end()
+    }
+}
+
+impl TryFrom<String> for CollectionReference {
+    type Error = anyhow::Error;
+
+    fn try_from(value: String) -> Result<Self, Self::Error> {
+        let mut slash_sep = value.split('/');
+        let first = slash_sep.next().context("empty collection reference")?;
+        let remaining = slash_sep.collect::<Vec<_>>();
+        let mut parts = remaining.chunks_exact(2);
+
+        let mut col_ref = collection(first);
+        for part in parts.by_ref() {
+            let (doc_id, collection_id) = (part[0], part[1]);
+            col_ref = col_ref.doc(doc_id).collection(collection_id);
+        }
+
+        anyhow::ensure!(
+            parts.remainder().is_empty(),
+            "invalid amount of path segments in collection reference"
+        );
+
+        Ok(col_ref)
+    }
+}
+
+impl<'de> Deserialize<'de> for CollectionReference {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let s: String = Deserialize::deserialize(deserializer)?;
+        Self::try_from(s).map_err(serde::de::Error::custom)
+    }
+}
+
+static DOC_REF_TYPE_ID: OnceCell<String> = OnceCell::new();
 
 impl DocumentReference {
     pub fn collection(&self, name: impl Into<String>) -> CollectionReference {
@@ -60,6 +118,56 @@ impl DocumentReference {
 
     pub fn id(&self) -> &str {
         &self.0.id
+    }
+
+    pub(crate) fn type_id() -> &'static str {
+        DOC_REF_TYPE_ID.get_or_init(|| format!("{:?}", TypeId::of::<Self>()))
+    }
+}
+
+impl Serialize for DocumentReference {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let mut s = serializer.serialize_struct(Self::type_id(), 1)?;
+        s.serialize_field("relative_path", &self.to_string())?;
+        s.end()
+    }
+}
+
+impl TryFrom<String> for DocumentReference {
+    type Error = anyhow::Error;
+
+    fn try_from(value: String) -> Result<Self, Self::Error> {
+        let slash_sep = value.split('/').collect::<Vec<_>>();
+        let mut parts = slash_sep.chunks_exact(2);
+
+        let mut doc_ref = None;
+        for part in parts.by_ref() {
+            let (collection_id, doc_id) = (part[0], part[1]);
+            doc_ref = match doc_ref {
+                None => Some(collection(collection_id).doc(doc_id)),
+                Some(parent) => Some(parent.collection(collection_id).doc(doc_id)),
+            };
+        }
+
+        anyhow::ensure!(
+            parts.remainder().is_empty(),
+            "invalid amount of path segments in document reference"
+        );
+
+        doc_ref.context("empty document reference")
+    }
+}
+
+impl<'de> Deserialize<'de> for DocumentReference {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let s: String = Deserialize::deserialize(deserializer)?;
+        Self::try_from(s).map_err(serde::de::Error::custom)
     }
 }
 
@@ -105,5 +213,55 @@ mod tests {
                 .to_string(),
             "planets/tatooine/people/luke"
         );
+    }
+
+    #[test]
+    fn deserialize_document_reference() {
+        #[derive(Debug, Deserialize)]
+        struct Test {
+            doc_ref: DocumentReference,
+        }
+
+        let tatooine: Test = serde_json::from_str(r#"{"doc_ref": "planets/tatooine"}"#).unwrap();
+        assert_eq!("planets/tatooine", tatooine.doc_ref.to_string());
+
+        let luke: Test =
+            serde_json::from_str(r#"{"doc_ref": "planets/tatooine/people/luke"}"#).unwrap();
+        assert_eq!("planets/tatooine/people/luke", luke.doc_ref.to_string());
+    }
+
+    #[test]
+    fn deserialize_invalid_document_reference_fails() {
+        #[derive(Debug, Deserialize)]
+        struct Test {
+            #[allow(unused)]
+            doc_ref: DocumentReference,
+        }
+
+        let res = serde_json::from_str::<Test>(r#"{"doc_ref": "planets"}"#);
+        assert!(res.is_err(), "expected error, got {:?}", res);
+    }
+
+    #[test]
+    fn deserialize_collection_reference() {
+        #[derive(Debug, Deserialize)]
+        struct Test {
+            col_ref: CollectionReference,
+        }
+
+        let test: Test = serde_json::from_str(r#"{"col_ref": "planets"}"#).unwrap();
+        assert_eq!("planets", test.col_ref.to_string());
+    }
+
+    #[test]
+    fn deserialize_invalid_collection_reference_fails() {
+        #[derive(Debug, Deserialize)]
+        struct Test {
+            #[allow(unused)]
+            col_ref: CollectionReference,
+        }
+
+        let res = serde_json::from_str::<Test>(r#"{"col_ref": "planets/tatooine"}"#);
+        assert!(res.is_err(), "expected error, got {:?}", res);
     }
 }

--- a/src/firestore/serde/serialize.rs
+++ b/src/firestore/serde/serialize.rs
@@ -36,16 +36,6 @@ impl DocumentSerializer {
         self
     }
 
-    pub fn create_time(mut self, timestamp: Timestamp) -> Self {
-        self.create_time = Some(timestamp);
-        self
-    }
-
-    pub fn update_time(mut self, timestamp: Timestamp) -> Self {
-        self.update_time = Some(timestamp);
-        self
-    }
-
     pub fn serialize<T: Serialize>(self, value: &T) -> Result<Document, Error> {
         let value_type = serialize(value, &self.root_resource_path)?;
 


### PR DESCRIPTION
- Save and fetch `DocumentReference` and `CollectionReference` types in the database via `serde`.
   - The types are saved as references in Firestore via Serialize
   - Reference types are visited as strings during deserialization, so you can deserialize with `...Reference`, `String`, or anything that can be made using a string
- Strip the beginning of the resource path when deserializing
- Add `PartialEq` to collection and document references so you can query them for equal references in the database.
- Instead of serializing up-front when constructing a filter for a query, postpone serialization until we actually need it in the query call. This also means we don't need to return a result after `filter` - this is a breaking change but for the better. We use type erasure from `erased_serde` to accomplish this.