### PR TITLE
Add AsRef implementations for reference types

### DIFF
--- a/src/firestore/reference.rs
+++ b/src/firestore/reference.rs
@@ -63,6 +63,18 @@ impl DocumentReference {
     }
 }
 
+impl AsRef<Self> for DocumentReference {
+    fn as_ref(&self) -> &Self {
+        self
+    }
+}
+
+impl AsRef<Self> for CollectionReference {
+    fn as_ref(&self) -> &Self {
+        self
+    }
+}
+
 impl std::fmt::Display for CollectionReference {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match &self.0.parent {


### PR DESCRIPTION
This should be handy for quite a lot of use cases. It will also allow us to use `impl AsRef<...Reference>` in the future for a nicer interface in the Firestore client.