### PR TITLE
Implement update and delete for existing documents

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -5,6 +5,9 @@ pub enum FirebaseError {
     #[error("{0}")]
     DocumentAlreadyExists(String),
 
+    #[error("{0}")]
+    DocumentNotfound(String),
+
     #[error("Email already exists")]
     EmailAlreadyExists,
 

--- a/src/firestore/client/mod.rs
+++ b/src/firestore/client/mod.rs
@@ -665,9 +665,7 @@ impl FirestoreClient {
 
         let request = DeleteDocumentRequest {
             name,
-            current_document: Some(Precondition {
-                condition_type: Some(ConditionType::Exists(true)),
-            }),
+            current_document: Self::document_exists_precondition(),
         };
 
         self.client


### PR DESCRIPTION
This PR implements and tests the following two functions:

- `update_existing_document`
- `delete_existing_document`

They're different from `set_document` and `delete_document`, in that they assume that the document already exists, and will return a new error `DocumentNotFound` if they don't.

In a scenario where we wish to make sure that the document really does exist before updating or deleting it, we can save resources by using these functions instead of using a combination of `get_document` and `set/delete_document`, 