### PR TITLE
Add prefix to serde and grpc error messages

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -14,10 +14,10 @@ pub enum FirebaseError {
     #[error("Failed to validate token: {0}")]
     ValidateTokenError(anyhow::Error),
 
-    #[error(transparent)]
+    #[error("serde: {0}")]
     FirestoreSerdeError(#[from] crate::firestore::serde::Error),
 
-    #[error(transparent)]
+    #[error("grpc: {0}")]
     GrpcError(#[from] tonic::transport::Error),
 
     #[error(transparent)]


### PR DESCRIPTION
Adds a prefix to the errors emitted by serde and tonic.

Before, only the bottommost error was shown. With this PR, you would know that the error came from serde by just looking at the error message itself:

```
        serde: premature end of input
Caused by:
        premature end of input
```

Closes #29 