### PR TITLE
Add count method to Firestore client

### DIFF
--- a/src/firestore/client/mod.rs
+++ b/src/firestore/client/mod.rs
@@ -1240,6 +1240,58 @@ impl FirestoreClient {
         .await
     }
 
+    /// Counts the number of documents that would be returned by the given query.
+    ///
+    /// The counting itself is done server-side by Firestore, so using this
+    /// function will be more efficient than executing the query and counting
+    /// how many documents were returned.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # #[tokio::main]
+    /// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// # let mut client = fireplace::firestore::test_helpers::initialise().await?;
+    /// use fireplace::firestore::{
+    ///     collection, collection_group,
+    ///     query::{filter, EqualTo},
+    /// };
+    ///
+    /// let landmarks = vec![
+    ///     (
+    ///         ("SF", "golden-gate"),
+    ///         serde_json::json!({ "name": "Golden Gate Bridge", "type": "bridge" }),
+    ///     ),
+    ///     (
+    ///         ("SF", "legion-honor"),
+    ///         serde_json::json!({ "name": "Legion of Honor", "type": "museum" }),
+    ///     ),
+    ///     (
+    ///         ("TOK", "national-science-museum"),
+    ///         serde_json::json!({ "name": "National Museum of Nature and Science", "type": "museum" }),
+    ///     ),
+    /// ];
+    ///
+    /// for ((city, landmark_id), landmark_data) in landmarks {
+    ///     client
+    ///         .set_document(
+    ///             &collection("cities")
+    ///                 .doc(city)
+    ///                 .collection("landmarks")
+    ///                 .doc(landmark_id),
+    ///             &landmark_data,
+    ///         )
+    ///         .await?;
+    /// }
+    ///
+    /// let number_of_museums = client
+    ///     .count(collection_group("landmarks").with_filter(filter("type", EqualTo("museum"))))
+    ///     .await?;
+    ///
+    /// assert_eq!(number_of_museums, 2);
+    /// # Ok(())
+    /// # }
+    /// ```
     pub async fn count<'de, 'a>(
         &'a mut self,
         query: impl FirestoreQuery<'a>,

--- a/src/firestore/client/mod.rs
+++ b/src/firestore/client/mod.rs
@@ -1292,7 +1292,7 @@ impl FirestoreClient {
     /// # Ok(())
     /// # }
     /// ```
-    pub async fn count<'de, 'a>(
+    pub async fn count<'a>(
         &'a mut self,
         query: impl FirestoreQuery<'a>,
     ) -> Result<u64, FirebaseError> {

--- a/src/firestore/client/mod.rs
+++ b/src/firestore/client/mod.rs
@@ -29,7 +29,7 @@ use crate::error::FirebaseError;
 use crate::firestore::serde::deserialize_firestore_document_fields;
 use crate::ServiceAccount;
 
-use super::query::{try_into_grpc_filter, ApiQueryOptions, Filter};
+use super::query::{try_into_grpc_filter, ApiQueryOptions, Filter, FirestoreQuery};
 use super::reference::{CollectionReference, DocumentReference};
 use super::serde::DocumentSerializer;
 use super::token_provider::FirestoreTokenProvider;
@@ -1242,16 +1242,10 @@ impl FirestoreClient {
 
     pub async fn count<'de, 'a>(
         &'a mut self,
-        collection_name: impl Into<String>,
-        filter: Filter<'a>,
+        query: impl FirestoreQuery<'a>,
     ) -> Result<u64, FirebaseError> {
-        let options = ApiQueryOptions {
-            parent: self.root_resource_path.clone(),
-            collection_name: collection_name.into(),
-            filter: Some(filter),
-            limit: None,
-            should_search_descendants: true,
-        };
+        let parent = self.root_resource_path.clone();
+        let options = ApiQueryOptions::from_query(parent, query);
 
         self.count_internal(options).await
     }

--- a/src/firestore/client/mod.rs
+++ b/src/firestore/client/mod.rs
@@ -1363,9 +1363,9 @@ impl FirestoreClient {
         Ok(count)
     }
 
-    fn structured_query_from_options<'a>(
+    fn structured_query_from_options(
         &self,
-        options: ApiQueryOptions<'a>,
+        options: ApiQueryOptions<'_>,
     ) -> Result<StructuredQuery, FirebaseError> {
         let grpc_filter = options
             .filter

--- a/src/firestore/mod.rs
+++ b/src/firestore/mod.rs
@@ -11,4 +11,5 @@ mod token_provider;
 /// Relevant rust-lang issue: <https://github.com/rust-lang/rust/issues/67295>
 pub mod test_helpers;
 
+pub use query::collection_group;
 pub use reference::collection;

--- a/src/firestore/reference.rs
+++ b/src/firestore/reference.rs
@@ -8,6 +8,8 @@ use anyhow::Context;
 use once_cell::sync::OnceCell;
 use serde::{ser::SerializeStruct, Deserialize, Deserializer, Serialize, Serializer};
 
+use super::query::{CollectionQuery, Filter};
+
 pub fn collection(name: impl Into<String>) -> CollectionReference {
     CollectionReference::new(name)
 }
@@ -58,6 +60,11 @@ impl CollectionReference {
 
     pub(crate) fn type_id() -> &'static str {
         COLLECTION_REF_TYPE_ID.get_or_init(hashed_type_id::<Self>)
+    }
+
+    /// Create a Firestore query with that filters documents from this collection.
+    pub fn with_filter(self, filter: Filter<'_>) -> CollectionQuery<'_> {
+        CollectionQuery::new(self).with_filter(filter)
     }
 }
 


### PR DESCRIPTION
Add a `.count(query)` method to `FirestoreClient` that returns the number of documents that the query would match. Rather than retrieving all the documents across the network, the counting is done server-side by Firestore.

This PR introduces a new trait, `FirestoreQuery`, which will make it possible to be generic over different query types. Currently, it is implemented for collection group queries, collection queries, and plain collection references (i.e. all docs in a collection).