### PR TITLE
Add method to obtain document reference for firestore documents

### DIFF
--- a/src/firestore/client/mod.rs
+++ b/src/firestore/client/mod.rs
@@ -31,7 +31,7 @@ use crate::ServiceAccount;
 
 use super::query::{try_into_grpc_filter, ApiQueryOptions, Filter, FirestoreQuery};
 use super::reference::{CollectionReference, DocumentReference};
-use super::serde::DocumentSerializer;
+use super::serde::{strip_reference_prefix, DocumentSerializer};
 use super::token_provider::FirestoreTokenProvider;
 
 mod options;
@@ -72,6 +72,16 @@ impl Clone for FirestoreClient {
             &self.project_id,
             self.options.clone(),
         )
+    }
+}
+
+impl<T> FirestoreDocument<T> {
+    /// Obtain a document reference to this document. May fail if the resource
+    /// path is invalid.
+    pub fn document_reference(&self) -> Result<DocumentReference, FirebaseError> {
+        let stripped_of_resource = strip_reference_prefix(&self.id);
+        let doc_ref = DocumentReference::try_from(stripped_of_resource)?;
+        Ok(doc_ref)
     }
 }
 

--- a/src/firestore/serde/deserialize.rs
+++ b/src/firestore/serde/deserialize.rs
@@ -279,7 +279,7 @@ impl<'de> de::Deserializer<'de> for FirestoreValueDeserializer {
     }
 }
 
-fn strip_reference_prefix(reference: &str) -> String {
+pub(crate) fn strip_reference_prefix(reference: &str) -> String {
     // Format: projects/{project_id}/databases/{database_id}/documents/{document_path}
     reference.split('/').skip(5).collect::<Vec<_>>().join("/")
 }


### PR DESCRIPTION
The `id` field is the full path to the resource - i.e. `projects/{project_id}/databases/{database_id}/documents/{document_path}`. The new `document_reference` method allows extracting the `document_path` segment into a `DocumentReference`.