### PR TITLE
Publish crate on crates.io

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,13 @@ name = "fireplace"
 version = "0.1.0"
 edition = "2021"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+description = "A client for Firebase that seeks to provide a user-friendly interface to interact with Firestore, Firebase Auth, and similar."
+license = "MIT"
+keywords = ["firebase", "firestore", "firebase-auth"]
+categories = ["database", "authentication", "web-programming"]
+repository = "https://github.com/Filify-app/fireplace"
+homepage = "https://github.com/Filify-app/fireplace"
+readme = "README.md"
 
 [dependencies]
 anyhow = "1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,20 +12,20 @@ homepage = "https://github.com/Filify-app/fireplace"
 readme = "README.md"
 
 [dependencies]
-anyhow = "1.0"
-firestore_grpc = "0.129"
-serde = { version = "1.0", features = ["derive"] }
-serde_json = "1.0"
-tokio = { version = "1.21", features = ["full"] }
-prost-types = "0.9"
-thiserror = "1.0"
-jsonwebtoken = "8.1"
-futures = "0.3"
-reqwest = { version = "0.11", features = ["json"] }
-tracing = "0.1"
-openssl = "0.10"
-once_cell = "1.16"
-erased-serde = "0.3"
+anyhow = "1.0.75"
+firestore_grpc = "0.191.0"
+serde = { version = "1.0.193", features = ["derive"] }
+serde_json = "1.0.108"
+tokio = { version = "1.34.0", features = ["full"] }
+prost-types = "0.9.0"
+thiserror = "1.0.50"
+jsonwebtoken = "9.1.0"
+futures = "0.3.29"
+reqwest = { version = "0.11.22", features = ["json"] }
+tracing = "0.1.40"
+openssl = "0.10.60"
+once_cell = "1.18.0"
+erased-serde = "0.3.31"
 
 [dev-dependencies]
-ulid = "1.0"
+ulid = "1.1.0"

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2022 Filify.app
+Copyright (c) 2023 Filify.app
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -6,9 +6,7 @@ This is a home-made client for Firebase's Admin SDK that seeks to provide a user
 
 ## Docs
 
-```sh
-cargo doc --open
-```
+View the crate documentation on [docs.rs](https://docs.rs/fireplace).
 
 ## Dependencies
 

--- a/README.md
+++ b/README.md
@@ -1,12 +1,11 @@
 # Fireplace
 
+[![Crates.io page](https://img.shields.io/crates/v/fireplace.svg?style=flat-square)](https://crates.io/crates/fireplace)
+[![docs.rs docs](https://img.shields.io/badge/docs-latest-blue.svg?style=flat-square)](https://docs.rs/fireplace)
+
 *The bestest, best Firebase library for Rust because there are no other libraries.*
 
 This is a home-made client for Firebase's Admin SDK that seeks to provide a user friendly interface to interact with Firestore, Firebase Auth, and similar.
-
-## Docs
-
-View the crate documentation on [docs.rs](https://docs.rs/fireplace).
 
 ## Dependencies
 
@@ -14,7 +13,7 @@ To verify ID tokens for Firebase Auth, OpenSSL is required. For installation, se
 
 ## Examples
 
-Check out the `examples` directory. Test-run the hello-world example with:
+Check out the `examples` directory or view the crate documentation on [docs.rs](https://docs.rs/fireplace), which includes many examples. Test-run the hello-world example with:
 
 ```
 cargo run --example hello


### PR DESCRIPTION
Fireplace is now available on crates.io: https://crates.io/crates/fireplace!

This is already published, but let's get the changes into `main` as well. :)