### PR TITLE
Add generic query method

### DIFF
--- a/src/firestore/client/mod.rs
+++ b/src/firestore/client/mod.rs
@@ -1377,7 +1377,7 @@ impl FirestoreClient {
         .await
     }
 
-    pub async fn execute_query<'de, 'a, T: Deserialize<'de> + 'a>(
+    pub async fn run_query<'de, 'a, T: Deserialize<'de> + 'a>(
         &'a mut self,
         query: impl FirestoreQuery<'a>,
     ) -> Result<FirebaseStream<T, FirebaseError>, FirebaseError> {
@@ -1385,7 +1385,7 @@ impl FirestoreClient {
         self.query_internal(options).await
     }
 
-    pub async fn execute_query_with_metadata<'de, 'a, T: Deserialize<'de> + 'a>(
+    pub async fn run_query_with_metadata<'de, 'a, T: Deserialize<'de> + 'a>(
         &'a mut self,
         query: impl FirestoreQuery<'a>,
     ) -> Result<FirebaseStream<FirestoreDocument<T>, FirebaseError>, FirebaseError> {

--- a/src/firestore/client/mod.rs
+++ b/src/firestore/client/mod.rs
@@ -913,6 +913,7 @@ impl FirestoreClient {
             collection_name,
             filter: Some(filter),
             limit: None,
+            offset: None,
             should_search_descendants: false,
         })
         .await
@@ -977,6 +978,7 @@ impl FirestoreClient {
                 collection_name,
                 filter: Some(filter),
                 limit: Some(1),
+                offset: None,
                 should_search_descendants: false,
             })
             .await?;
@@ -1121,6 +1123,7 @@ impl FirestoreClient {
             collection_name: collection_name.into(),
             filter: None,
             limit: None,
+            offset: None,
             should_search_descendants: true,
         })
         .await
@@ -1211,6 +1214,7 @@ impl FirestoreClient {
             collection_name: collection_name.into(),
             filter: Some(filter),
             limit: None,
+            offset: None,
             should_search_descendants: true,
         })
         .await
@@ -1299,6 +1303,7 @@ impl FirestoreClient {
             collection_name: collection_name.into(),
             filter: Some(filter),
             limit: None,
+            offset: None,
             should_search_descendants: true,
         })
         .await
@@ -1366,9 +1371,26 @@ impl FirestoreClient {
             collection_name,
             filter: None,
             limit: None,
+            offset: None,
             should_search_descendants: false,
         })
         .await
+    }
+
+    pub async fn execute_query<'de, 'a, T: Deserialize<'de> + 'a>(
+        &'a mut self,
+        query: impl FirestoreQuery<'a>,
+    ) -> Result<FirebaseStream<T, FirebaseError>, FirebaseError> {
+        let options = ApiQueryOptions::from_query(self, query);
+        self.query_internal(options).await
+    }
+
+    pub async fn execute_query_with_metadata<'de, 'a, T: Deserialize<'de> + 'a>(
+        &'a mut self,
+        query: impl FirestoreQuery<'a>,
+    ) -> Result<FirebaseStream<FirestoreDocument<T>, FirebaseError>, FirebaseError> {
+        let options = ApiQueryOptions::from_query(self, query);
+        self.query_internal_with_metadata(options).await
     }
 
     /// Counts the number of documents that would be returned by the given query.
@@ -1529,7 +1551,7 @@ impl FirestoreClient {
             order_by: vec![],
             start_at: None,
             end_at: None,
-            offset: 0,
+            offset: options.offset.unwrap_or(0),
             limit: options.limit,
         };
 

--- a/src/firestore/mod.rs
+++ b/src/firestore/mod.rs
@@ -115,7 +115,7 @@
 //! use futures::TryStreamExt;
 //!
 //! let query = collection("cities").doc("SF").collection("landmarks");
-//! let sf_landmarks: Vec<Landmark> = client.execute_query(query).await?.try_collect().await?;
+//! let sf_landmarks: Vec<Landmark> = client.run_query(query).await?.try_collect().await?;
 //!
 //! assert_eq!(
 //!     sf_landmarks,
@@ -155,7 +155,7 @@
 //!     .doc("SF")
 //!     .collection("landmarks")
 //!     .with_filter(filter("type", EqualTo("museum")));
-//! let sf_museums: Vec<Landmark> = client.execute_query(query).await?.try_collect().await?;
+//! let sf_museums: Vec<Landmark> = client.run_query(query).await?.try_collect().await?;
 //!
 //! assert_eq!(
 //!     sf_museums.into_iter().map(|m| m.name).collect::<Vec<_>>(),
@@ -181,7 +181,7 @@
 //! use fireplace::firestore::collection_group;
 //!
 //! let query = collection_group("landmarks").with_filter(filter("type", EqualTo("museum")));
-//! let museums: Vec<Landmark> = client.execute_query(query).await?.try_collect().await?;
+//! let museums: Vec<Landmark> = client.run_query(query).await?.try_collect().await?;
 //!
 //! assert_eq!(
 //!     museums.into_iter().map(|m| m.name).collect::<Vec<_>>(),
@@ -205,7 +205,7 @@
 //! # fireplace::firestore::test_helpers::setup_landmarks_example(&mut client).await?;
 //! let query = collection_group("landmarks").with_filter(filter("type", EqualTo("museum")));
 //! let museums_with_metadata: Vec<FirestoreDocument<Landmark>> = client
-//!     .execute_query_with_metadata(query)
+//!     .run_query_with_metadata(query)
 //!     .await?
 //!     .try_collect()
 //!     .await?;
@@ -261,10 +261,10 @@
 //! # let mut client = fireplace::firestore::test_helpers::initialise().await?;
 //! # fireplace::firestore::test_helpers::setup_landmarks_example(&mut client).await?;
 //! let query = collection_group("landmarks").with_limit(2);
-//! let page_one: Vec<Landmark> = client.execute_query(query).await?.try_collect().await?;
+//! let page_one: Vec<Landmark> = client.run_query(query).await?.try_collect().await?;
 //!
 //! let query = collection_group("landmarks").with_limit(2).with_offset(2);
-//! let page_two: Vec<Landmark> = client.execute_query(query).await?.try_collect().await?;
+//! let page_two: Vec<Landmark> = client.run_query(query).await?.try_collect().await?;
 //!
 //! assert_eq!(
 //!     page_one.into_iter().map(|m| m.name).collect::<Vec<_>>(),

--- a/src/firestore/mod.rs
+++ b/src/firestore/mod.rs
@@ -11,7 +11,7 @@
 //!
 //! ## Initializing the client
 //!
-//! ```
+//! ```no_run
 //! # #[tokio::main]
 //! # async fn main() {
 //! use fireplace::{

--- a/src/firestore/mod.rs
+++ b/src/firestore/mod.rs
@@ -1,3 +1,283 @@
+//! # Firestore
+//!
+//! - [Initializing the client](#initializing-the-client)
+//! - [Query examples](#query-examples)
+//!    * [Setting the documents](#setting-the-documents)
+//!    * [Listing all documents in a collection](#listing-all-documents-in-a-collection)
+//!    * [Filtering documents in a collection](#filtering-documents-in-a-collection)
+//!    * [Collection group queries](#collection-group-queries)
+//!    * [Using document metadata](#using-document-metadata)
+//!    * [Paginated queries](#paginated-queries)
+//!
+//! ## Initializing the client
+//!
+//! ```
+//! # #[tokio::main]
+//! # async fn main() {
+//! use fireplace::{
+//!     ServiceAccount,
+//!     firestore::client::{FirestoreClient, FirestoreClientOptions}
+//! };
+//!
+//! // Load the service account, which specifies which project we will connect
+//! // to and the secret keys used for authentication.
+//! let service_account = ServiceAccount::from_file("./test-service-account.json").unwrap();
+//!
+//! // Configure the client - we just want the default.
+//! let client_options = FirestoreClientOptions::default();
+//!
+//! // Finally, create a client for Firestore.
+//! let mut client = FirestoreClient::initialise(service_account, client_options)
+//!     .await
+//!     .unwrap();
+//! # }
+//! ```
+//!
+//! ## Query examples
+//!
+//! For the following examples, we will use the following database instance
+//! that contains landmarks across some cities:
+//!
+//! ```text
+//! cities (collection)
+//! ├── SF (doc)
+//! │   └── landmarks (collection)
+//! │       ├── golden-gate: Golden Gate Bridge (type: bridge)
+//! │       └── legion-honor: Legion of Honor (type: museum)
+//! └── TOK (doc)
+//!     └── landmarks (collection)
+//!         └── national-science-museum: National Museum of Nature and Science (type: museum)
+//! ```
+//!
+//! ### Setting the documents
+//!
+//! To write a document to Firestore, you can use the [`set_document`] method. The following
+//! writes the documents specified above:
+//!
+//! [`set_document`]: crate::firestore::client::FirestoreClient::set_document
+//!
+//! ```
+//! # #[tokio::main]
+//! # async fn main() -> Result<(), Box<dyn std::error::Error>> {
+//! # use serde::Deserialize;
+//! # let mut client = fireplace::firestore::test_helpers::initialise().await.unwrap();
+//! use fireplace::firestore::collection;
+//!
+//! #[derive(Deserialize, Debug, PartialEq)]
+//! struct Landmark {
+//!     pub name: String,
+//!     pub r#type: String,
+//! }
+//!
+//! client
+//!     .set_document(
+//!         &collection("cities")
+//!             .doc("SF")
+//!             .collection("landmarks")
+//!             .doc("golden-gate"),
+//!         &serde_json::json!({ "name": "Golden Gate Bridge", "type": "bridge" }),
+//!     )
+//!     .await?;
+//!
+//! client
+//!     .set_document(
+//!         &collection("cities")
+//!             .doc("SF")
+//!             .collection("landmarks")
+//!             .doc("legion-honor"),
+//!         &serde_json::json!({ "name": "Legion of Honor", "type": "museum" }),
+//!     )
+//!     .await?;
+//!
+//! client
+//!     .set_document(
+//!         &collection("cities")
+//!             .doc("TOK")
+//!             .collection("landmarks")
+//!             .doc("national-science-museum"),
+//!         &serde_json::json!({ "name": "National Museum of Nature and Science", "type": "museum" }),
+//!     )
+//!     .await?;
+//! # Ok(())
+//! # }
+//! ```
+//!
+//! ### Listing all documents in a collection
+//!
+//! The following example lists all documents in `cities/SF/landmarks`:
+//!
+//! ```
+//! # #[tokio::main]
+//! # async fn main() -> Result<(), Box<dyn std::error::Error>> {
+//! # use fireplace::firestore::{collection, test_helpers::Landmark};
+//! # let mut client = fireplace::firestore::test_helpers::initialise().await?;
+//! # fireplace::firestore::test_helpers::setup_landmarks_example(&mut client).await?;
+//! use futures::TryStreamExt;
+//!
+//! let query = collection("cities").doc("SF").collection("landmarks");
+//! let sf_landmarks: Vec<Landmark> = client.execute_query(query).await?.try_collect().await?;
+//!
+//! assert_eq!(
+//!     sf_landmarks,
+//!     vec![
+//!         Landmark {
+//!             name: "Golden Gate Bridge".to_string(),
+//!             r#type: "bridge".to_string()
+//!         },
+//!         Landmark {
+//!             name: "Legion of Honor".to_string(),
+//!             r#type: "museum".to_string()
+//!         },
+//!     ]
+//! );
+//! # Ok(())
+//! # }
+//! ```
+//!
+//! ### Filtering documents in a collection
+//!
+//! The previous query can be extended with a [`filter`] to only return
+//! documents that fulfil the given condition. For example, we can filter
+//! the landmarks by their `type` field:
+//!
+//! [`filter`]: crate::firestore::query::filter
+//!
+//! ```
+//! # #[tokio::main]
+//! # async fn main() -> Result<(), Box<dyn std::error::Error>> {
+//! # use fireplace::firestore::{collection, test_helpers::Landmark};
+//! # use futures::TryStreamExt;
+//! # let mut client = fireplace::firestore::test_helpers::initialise().await?;
+//! # fireplace::firestore::test_helpers::setup_landmarks_example(&mut client).await?;
+//! use fireplace::firestore::query::{filter, EqualTo};
+//!
+//! let query = collection("cities")
+//!     .doc("SF")
+//!     .collection("landmarks")
+//!     .with_filter(filter("type", EqualTo("museum")));
+//! let sf_museums: Vec<Landmark> = client.execute_query(query).await?.try_collect().await?;
+//!
+//! assert_eq!(
+//!     sf_museums.into_iter().map(|m| m.name).collect::<Vec<_>>(),
+//!     ["Legion of Honor"]
+//! );
+//! # Ok(())
+//! # }
+//! ```
+//!
+//! ### Collection group queries
+//!
+//! Collection group queries allow you to query across multiple collections
+//! that share the same name. For example, we can query all museums across
+//! all cities:
+//!
+//! ```
+//! # #[tokio::main]
+//! # async fn main() -> Result<(), Box<dyn std::error::Error>> {
+//! # use fireplace::firestore::{collection, test_helpers::Landmark, query::{filter, EqualTo}};
+//! # use futures::TryStreamExt;
+//! # let mut client = fireplace::firestore::test_helpers::initialise().await?;
+//! # fireplace::firestore::test_helpers::setup_landmarks_example(&mut client).await?;
+//! use fireplace::firestore::collection_group;
+//!
+//! let query = collection_group("landmarks").with_filter(filter("type", EqualTo("museum")));
+//! let museums: Vec<Landmark> = client.execute_query(query).await?.try_collect().await?;
+//!
+//! assert_eq!(
+//!     museums.into_iter().map(|m| m.name).collect::<Vec<_>>(),
+//!     ["Legion of Honor", "National Museum of Nature and Science"]
+//! );
+//! # Ok(())
+//! # }
+//! ```
+//!
+//! ### Using document metadata
+//!
+//! It is sometimes useful to obtain the document metadata, such as document
+//! references to query results, or document creation and last-updated-at times.
+//!
+//! ```
+//! # #[tokio::main]
+//! # async fn main() -> Result<(), Box<dyn std::error::Error>> {
+//! # use fireplace::firestore::{collection, collection_group, test_helpers::Landmark, query::{filter, EqualTo}, client::FirestoreDocument};
+//! # use futures::TryStreamExt;
+//! # let mut client = fireplace::firestore::test_helpers::initialise().await?;
+//! # fireplace::firestore::test_helpers::setup_landmarks_example(&mut client).await?;
+//! let query = collection_group("landmarks").with_filter(filter("type", EqualTo("museum")));
+//! let museums_with_metadata: Vec<FirestoreDocument<Landmark>> = client
+//!     .execute_query_with_metadata(query)
+//!     .await?
+//!     .try_collect()
+//!     .await?;
+//!
+//! assert_eq!(
+//!     museums_with_metadata
+//!         .iter()
+//!         .map(|m| &m.data.name)
+//!         .collect::<Vec<_>>(),
+//!     ["Legion of Honor", "National Museum of Nature and Science"]
+//! );
+//!
+//! // For example, we can get document references to the retrieved documents
+//!
+//! let museum_references = museums_with_metadata
+//!     .iter()
+//!     .map(|m| m.document_reference())
+//!     .collect::<Result<Vec<_>, _>>()?;
+//!
+//! assert_eq!(
+//!     museum_references,
+//!     [
+//!         collection("cities")
+//!             .doc("SF")
+//!             .collection("landmarks")
+//!             .doc("legion-honor"),
+//!         collection("cities")
+//!             .doc("TOK")
+//!             .collection("landmarks")
+//!             .doc("national-science-museum"),
+//!     ]
+//! );
+//!
+//! // Or we can get information about when the documents were created and last updated
+//!
+//! println!(
+//!     "Document created at timestamp {:?} and last updated at {:?}",
+//!     museums_with_metadata[0].create_time, museums_with_metadata[0].update_time
+//! );
+//! # Ok(())
+//! # }
+//! ```
+//!
+//! ### Paginated queries
+//!
+//! To paginate queries, you can specify limits and offsets.
+//!
+//! ```
+//! # #[tokio::main]
+//! # async fn main() -> Result<(), Box<dyn std::error::Error>> {
+//! # use fireplace::firestore::{collection_group, test_helpers::Landmark};
+//! # use futures::TryStreamExt;
+//! # let mut client = fireplace::firestore::test_helpers::initialise().await?;
+//! # fireplace::firestore::test_helpers::setup_landmarks_example(&mut client).await?;
+//! let query = collection_group("landmarks").with_limit(2);
+//! let page_one: Vec<Landmark> = client.execute_query(query).await?.try_collect().await?;
+//!
+//! let query = collection_group("landmarks").with_limit(2).with_offset(2);
+//! let page_two: Vec<Landmark> = client.execute_query(query).await?.try_collect().await?;
+//!
+//! assert_eq!(
+//!     page_one.into_iter().map(|m| m.name).collect::<Vec<_>>(),
+//!     ["Golden Gate Bridge", "Legion of Honor"]
+//! );
+//! assert_eq!(
+//!     page_two.into_iter().map(|m| m.name).collect::<Vec<_>>(),
+//!     ["National Museum of Nature and Science"]
+//! );
+//! # Ok(())
+//! # }
+//! ```
+
 pub mod client;
 pub mod query;
 pub mod reference;

--- a/src/firestore/query.rs
+++ b/src/firestore/query.rs
@@ -288,6 +288,7 @@ pub(crate) struct ApiQueryOptions<'a> {
     pub collection_name: String,
     pub filter: Option<Filter<'a>>,
     pub limit: Option<i32>,
+    pub offset: Option<i32>,
     /// Whether to search descendant collections with the same name
     pub should_search_descendants: bool,
 }
@@ -306,6 +307,7 @@ impl<'a> ApiQueryOptions<'a> {
             parent: parent_path,
             collection_name: query.collection_name().to_string(),
             limit: query.limit(),
+            offset: query.offset(),
             should_search_descendants: query.should_search_descendants(),
             filter: query.filter(),
         }
@@ -318,11 +320,14 @@ pub trait FirestoreQuery<'a> {
     fn parent_path(&self) -> Option<String>;
     fn should_search_descendants(&self) -> bool;
     fn limit(&self) -> Option<i32>;
+    fn offset(&self) -> Option<i32>;
 }
 
 pub struct CollectionGroupQuery<'a> {
     collection_name: String,
     filter: Option<Filter<'a>>,
+    limit: Option<i32>,
+    offset: Option<i32>,
 }
 
 pub fn collection_group<'a>(collection_name: impl Into<String>) -> CollectionGroupQuery<'a> {
@@ -334,11 +339,23 @@ impl<'a> CollectionGroupQuery<'a> {
         CollectionGroupQuery {
             collection_name: collection_name.into(),
             filter: None,
+            limit: None,
+            offset: None,
         }
     }
 
     pub fn with_filter(mut self, filter: Filter<'a>) -> Self {
         self.filter = Some(filter);
+        self
+    }
+
+    pub fn with_limit(mut self, limit: u32) -> Self {
+        self.limit = Some(limit as i32);
+        self
+    }
+
+    pub fn with_offset(mut self, offset: u32) -> Self {
+        self.offset = Some(offset as i32);
         self
     }
 }
@@ -361,7 +378,11 @@ impl<'a> FirestoreQuery<'a> for CollectionGroupQuery<'a> {
     }
 
     fn limit(&self) -> Option<i32> {
-        None
+        self.limit
+    }
+
+    fn offset(&self) -> Option<i32> {
+        self.offset
     }
 }
 
@@ -385,11 +406,17 @@ impl<'a> FirestoreQuery<'a> for CollectionReference {
     fn limit(&self) -> Option<i32> {
         None
     }
+
+    fn offset(&self) -> Option<i32> {
+        None
+    }
 }
 
 pub struct CollectionQuery<'a> {
     collection: CollectionReference,
     filter: Option<Filter<'a>>,
+    limit: Option<i32>,
+    offset: Option<i32>,
 }
 
 impl<'a> CollectionQuery<'a> {
@@ -397,11 +424,23 @@ impl<'a> CollectionQuery<'a> {
         CollectionQuery {
             collection,
             filter: None,
+            limit: None,
+            offset: None,
         }
     }
 
     pub fn with_filter(mut self, filter: Filter<'a>) -> Self {
         self.filter = Some(filter);
+        self
+    }
+
+    pub fn with_limit(mut self, limit: u32) -> Self {
+        self.limit = Some(limit as i32);
+        self
+    }
+
+    pub fn with_offset(mut self, offset: u32) -> Self {
+        self.offset = Some(offset as i32);
         self
     }
 }
@@ -424,7 +463,11 @@ impl<'a> FirestoreQuery<'a> for CollectionQuery<'a> {
     }
 
     fn limit(&self) -> Option<i32> {
-        self.collection.limit()
+        self.limit
+    }
+
+    fn offset(&self) -> Option<i32> {
+        self.offset
     }
 }
 

--- a/src/firestore/reference.rs
+++ b/src/firestore/reference.rs
@@ -62,9 +62,19 @@ impl CollectionReference {
         COLLECTION_REF_TYPE_ID.get_or_init(hashed_type_id::<Self>)
     }
 
-    /// Create a Firestore query with that filters documents from this collection.
+    /// Create a Firestore query that filters documents from this collection.
     pub fn with_filter(self, filter: Filter<'_>) -> CollectionQuery<'_> {
         CollectionQuery::new(self).with_filter(filter)
+    }
+
+    /// Create a Firestore query that limits how many documents are returned.
+    pub fn with_limit<'a>(self, limit: u32) -> CollectionQuery<'a> {
+        CollectionQuery::new(self).with_limit(limit)
+    }
+
+    /// Create a Firestore query that specifies an offset for pagination.
+    pub fn with_offset<'a>(self, offset: u32) -> CollectionQuery<'a> {
+        CollectionQuery::new(self).with_offset(offset)
     }
 }
 

--- a/src/firestore/test_helpers.rs
+++ b/src/firestore/test_helpers.rs
@@ -1,6 +1,11 @@
 use std::env;
 
-use crate::{firestore::client::FirestoreClient, ServiceAccount};
+use serde::Deserialize;
+
+use crate::{
+    firestore::{client::FirestoreClient, collection},
+    ServiceAccount,
+};
 
 use super::client::FirestoreClientOptions;
 
@@ -19,4 +24,44 @@ pub async fn initialise() -> Result<FirestoreClient, anyhow::Error> {
         .unwrap();
 
     Ok(client)
+}
+
+#[derive(Deserialize, Debug, PartialEq)]
+pub struct Landmark {
+    pub name: String,
+    pub r#type: String,
+}
+
+pub async fn setup_landmarks_example(client: &mut FirestoreClient) -> Result<(), anyhow::Error> {
+    client
+        .set_document(
+            &collection("cities")
+                .doc("SF")
+                .collection("landmarks")
+                .doc("golden-gate"),
+            &serde_json::json!({ "name": "Golden Gate Bridge", "type": "bridge" }),
+        )
+        .await?;
+
+    client
+        .set_document(
+            &collection("cities")
+                .doc("SF")
+                .collection("landmarks")
+                .doc("legion-honor"),
+            &serde_json::json!({ "name": "Legion of Honor", "type": "museum" }),
+        )
+        .await?;
+
+    client
+        .set_document(
+            &collection("cities")
+                .doc("TOK")
+                .collection("landmarks")
+                .doc("national-science-museum"),
+            &serde_json::json!({ "name": "National Museum of Nature and Science", "type": "museum" }),
+        )
+        .await?;
+
+    Ok(())
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,10 @@
 //!
 //! Fireplace is a client for Firebase that seeks to provide a user-friendly
 //! interface to interact with Firestore, Firebase Auth, and similar.
+//!
+//! ## Firestore usage
+//!
+//! See the [`firestore`] module for more information.
 
 pub mod auth;
 pub mod error;


### PR DESCRIPTION
Adds a new, generic `run_query` method that supports getting all docs in a collection or collection group as well as filtering those documents. It's essentially all of the current query methods combined into a single one.

See the updated docs for examples and tests.

Additionally, this PR makes pagination possible via `limit` and `offset`.