### PR TITLE
Add method to combine filters

### DIFF
--- a/src/firestore/query.rs
+++ b/src/firestore/query.rs
@@ -160,6 +160,10 @@ pub struct FieldFilter<'a> {
 }
 
 impl<'a> Filter<'a> {
+    pub fn empty() -> Self {
+        Self::Composite(vec![])
+    }
+
     pub fn and<T: Serialize + 'a + Send>(
         self,
         field: impl Into<String> + 'a,

--- a/src/firestore/query.rs
+++ b/src/firestore/query.rs
@@ -181,6 +181,22 @@ impl<'a> Filter<'a> {
 
         new_filter
     }
+
+    pub fn combine(self, other: Self) -> Self {
+        let (mut filters, other) = match (self, other) {
+            (Self::Composite(filters), other) | (other, Self::Composite(filters)) => {
+                (filters, other)
+            }
+            (Self::Single(filter), other) => (vec![filter], other),
+        };
+
+        match other {
+            Self::Composite(other_filters) => filters.extend(other_filters),
+            Self::Single(other_filter) => filters.push(other_filter),
+        }
+
+        Self::Composite(filters)
+    }
 }
 
 fn create_field_filter<'a, T, Q>(field: String, query_op: Q) -> FieldFilter<'a>


### PR DESCRIPTION
Useful for cases where you want to combine multiple existing filters into one. For example, you might automatically generate Firestore filters based on some filters of your own - this now becomes an easy fold:

```rs
my_filters
    .into_iter()
    .map(MyFilter::to_firestore_filter)
    .fold(Filter::empty(), Filter::combine);
```