### PR TITLE
Add `batch_get_documents` method to fetch many documents at once

### DIFF
--- a/src/firestore/client/mod.rs
+++ b/src/firestore/client/mod.rs
@@ -1549,8 +1549,10 @@ impl FirestoreClient {
     pub async fn batch_get_documents<'de, 'a, T: Deserialize<'de>>(
         &'a mut self,
         documents: impl IntoIterator<Item = &'a DocumentReference>,
-    ) -> Result<FirebaseStream<Result<FirestoreDocument<T>, String>, FirebaseError>, FirebaseError>
-    {
+    ) -> Result<
+        FirebaseStream<'a, Result<FirestoreDocument<T>, String>, FirebaseError>,
+        FirebaseError,
+    > {
         let doc_refs = documents
             .into_iter()
             .map(|doc_ref| self.get_name_with(doc_ref))


### PR DESCRIPTION
Refer to the documentation on each of the methods for explanations and examples of usages of the methods.

> [!NOTE]
> (Old note) ~~This PR has kind of left behind. It's still a nice update to the library, and it's ready to be merged as soon as tests have been added.~~
> 
> ~~However, we no longer needed the new functions, so we haven't spent time finishing the PR.~~

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Batch retrieval of multiple documents in a single request.
  * Option to return results in the same order as requested.
  * Missing documents are clearly indicated in results.
  * Streaming support for large batches to improve performance and responsiveness.

* **Refactor**
  * Internal path handling consolidated for more consistent and reliable requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->