### PR TITLE
Add method to retrieve all users from Firebase Auth

### DIFF
--- a/src/auth/credential/api_auth_token.rs
+++ b/src/auth/credential/api_auth_token.rs
@@ -52,9 +52,7 @@ impl ApiAuthTokenManager {
             "grant_type=urn%3Aietf%3Aparams%3Aoauth%3Agrant-type%3Ajwt-bearer&assertion={jwt}"
         );
 
-        let url = format!(
-            "https://{GOOGLE_AUTH_TOKEN_HOST}{GOOGLE_AUTH_TOKEN_PATH}"
-        );
+        let url = format!("https://{GOOGLE_AUTH_TOKEN_HOST}{GOOGLE_AUTH_TOKEN_PATH}");
 
         let res = self
             .http_client

--- a/src/auth/mod.rs
+++ b/src/auth/mod.rs
@@ -448,19 +448,15 @@ impl FirebaseAuthClient {
             .map(|range| run_worker(self, range, &base_url));
 
         let worker_results = futures::future::try_join_all(futures).await?;
-        let mut deduped = HashMap::new();
 
+        let mut deduped = HashMap::new();
         for users in worker_results {
             for user in users {
                 deduped.insert(user.uid.clone(), user);
             }
         }
 
-        let keys = deduped.keys().cloned().collect::<Vec<_>>();
-        let all_users = keys
-            .iter()
-            .map(|k| deduped.remove(k).unwrap())
-            .collect::<Vec<_>>();
+        let all_users = deduped.into_values().collect();
 
         Ok(all_users)
     }

--- a/src/auth/models/mod.rs
+++ b/src/auth/models/mod.rs
@@ -13,6 +13,13 @@ pub(crate) struct GetAccountInfoResponse {
 
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
+pub(crate) struct BatchGetResponse {
+    pub users: Option<Vec<User>>,
+    pub next_page_token: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct User {
     #[serde(rename = "localId")]
     pub uid: String,


### PR DESCRIPTION
Adds two new methods to the Firebase Auth client:
- `get_all_users`, which retrieves all users from Firebase Auth (the multi-user version of `get_user`)
- `get_all_users_concurrently`, which retrieves the users using a specified number of workers, which can speed up the retrieval significantly for large user sets

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Added ability to fetch all users from Firebase Auth, including a public convenience method for full-user retrieval and an option for concurrent retrieval.
- Performance
  - Faster bulk user retrieval via concurrency, pagination handling, and result de-duplication.
- Refactor
  - Centralized project-scoped endpoint handling and unified per-request authorization; improved access token handling and clearer error logging.
- Compatibility
  - No breaking changes to the public API.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->