### PR TITLE
Add ability to disable/enable users

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,7 @@ jobs:
           profile: minimal
           toolchain: stable
           override: true
+      - run: rustup component add rustfmt
       - uses: actions-rs/cargo@v1
         with:
           command: check
@@ -52,6 +53,7 @@ jobs:
           toolchain: stable
           override: true
       - run: rustup component add clippy
+      - run: rustup component add rustfmt
       - uses: actions-rs/cargo@v1
         with:
           command: clippy
@@ -67,6 +69,7 @@ jobs:
           profile: minimal
           toolchain: stable
           override: true
+      - run: rustup component add rustfmt
       - name: Run tests
         env:
           FIREBASE_PROJECT_ID: ${{ secrets.FIREBASE_PROJECT_ID }}

--- a/src/auth/mod.rs
+++ b/src/auth/mod.rs
@@ -599,6 +599,15 @@ impl FirebaseAuthClient {
     /// // Verify the user is disabled
     /// let user = auth_client.get_user(&user_id).await?.unwrap();
     /// assert_eq!(user.disabled, Some(true));
+    ///
+    /// // Re-enable the user
+    /// auth_client
+    ///     .update_user(&user_id, UpdateUserValues::new().disabled(false))
+    ///     .await?;
+    ///
+    /// // Verify the user is enabled again
+    /// let user = auth_client.get_user(&user_id).await?.unwrap();
+    /// assert_eq!(user.disabled, Some(false));
     /// # Ok(())
     /// # }
     /// ```

--- a/src/auth/mod.rs
+++ b/src/auth/mod.rs
@@ -573,6 +573,35 @@ impl FirebaseAuthClient {
     /// # Ok(())
     /// # }
     /// ```
+    ///
+    /// Disable a user:
+    ///
+    /// ```
+    /// # #[tokio::main]
+    /// # async fn main() -> Result<(), fireplace::error::FirebaseError> {
+    /// # let auth_client = fireplace::auth::test_helpers::initialise()?;
+    /// use fireplace::auth::models::{NewUser, UpdateUserValues};
+    /// use ulid::Ulid;
+    ///
+    /// let user_id = auth_client
+    ///     .create_user(NewUser {
+    ///         display_name: Some("Test User".to_string()),
+    ///         email: format!("{}@example.com", Ulid::new()),
+    ///         password: Ulid::new().to_string(),
+    ///     })
+    ///     .await?;
+    ///
+    /// // Disable the user
+    /// auth_client
+    ///     .update_user(&user_id, UpdateUserValues::new().disabled(true))
+    ///     .await?;
+    ///
+    /// // Verify the user is disabled
+    /// let user = auth_client.get_user(&user_id).await?.unwrap();
+    /// assert_eq!(user.disabled, Some(true));
+    /// # Ok(())
+    /// # }
+    /// ```
     #[tracing::instrument(name = "Update user", skip_all, fields(user_id = %user_id.as_ref()))]
     pub async fn update_user(
         &self,

--- a/src/auth/models/update_user.rs
+++ b/src/auth/models/update_user.rs
@@ -53,7 +53,7 @@ pub(crate) struct UpdateUserBody<'a> {
     #[serde(skip_serializing_if = "Vec::is_empty")]
     delete_attribute: Vec<&'static str>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    disabled: Option<bool>,
+    disable_user: Option<bool>,
 }
 
 impl<'a> UpdateUserBody<'a> {
@@ -72,7 +72,11 @@ impl<'a> UpdateUserBody<'a> {
             email: values.email,
             password: values.password,
             delete_attribute,
-            disabled: values.disabled,
+            // The `disabled` field is internally renamed to `disableUser`. See the Firebase Node
+            // Admin SDK implementation for reference:
+            //   - https://github.com/firebase/firebase-admin-node/blob/137a0d9312b0b45b69f6a5111081420729d8eaeb/src/auth/auth-api-request.ts#L480-L486
+            //   - https://github.com/firebase/firebase-admin-node/blob/137a0d9312b0b45b69f6a5111081420729d8eaeb/src/auth/auth-api-request.ts#L1468-L1472
+            disable_user: values.disabled,
         }
     }
 }

--- a/src/auth/models/update_user.rs
+++ b/src/auth/models/update_user.rs
@@ -6,6 +6,7 @@ pub struct UpdateUserValues {
     display_name: Option<Option<String>>,
     email: Option<String>,
     password: Option<String>,
+    disabled: Option<bool>,
 }
 
 impl UpdateUserValues {
@@ -31,6 +32,12 @@ impl UpdateUserValues {
         self.password = Some(password.into());
         self
     }
+
+    /// Enable or disable the user.
+    pub fn disabled(mut self, disabled: bool) -> Self {
+        self.disabled = Some(disabled);
+        self
+    }
 }
 
 #[derive(Serialize)]
@@ -45,6 +52,8 @@ pub(crate) struct UpdateUserBody<'a> {
     password: Option<String>,
     #[serde(skip_serializing_if = "Vec::is_empty")]
     delete_attribute: Vec<&'static str>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    disabled: Option<bool>,
 }
 
 impl<'a> UpdateUserBody<'a> {
@@ -63,6 +72,7 @@ impl<'a> UpdateUserBody<'a> {
             email: values.email,
             password: values.password,
             delete_attribute,
+            disabled: values.disabled,
         }
     }
 }


### PR DESCRIPTION
Adds support for disabling and enabling user accounts via the `disabled()` method on `UpdateUserValues`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - You can now disable or re-enable a user account as part of an update, via an optional flag while remaining backward compatible.

- **Documentation**
  - Added a step-by-step example demonstrating disabling a user, verifying the disabled state, then re-enabling and verifying again.

- **Chores**
  - CI updated to install formatting tooling before running checks, linting, and tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->